### PR TITLE
Don't use Azure CLI on CI, DEV-730

### DIFF
--- a/packer/build-probe-azure.sh
+++ b/packer/build-probe-azure.sh
@@ -3,12 +3,14 @@
 set -eu
 
 client_cert_path="$1"
-java_major="$2"
-location="$3"
-resource_group="$4"
-ssh_private_key_file="$5"
-ssh_username="$6"
-storage_account="$7"
+client_id="$2"
+java_major="$3"
+location="$4"
+resource_group="$5"
+ssh_private_key_file="$6"
+ssh_username="$7"
+storage_account="$8"
+subscription_id="$9"
 
 adoptopenjdk_url="https://api.adoptopenjdk.net/v2/latestAssets/releases/openjdk${java_major}?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk"
 java_version=$(curl -Ls "${adoptopenjdk_url}" | jq -r 'map(.version_data.openjdk_version) | .[]')
@@ -16,8 +18,13 @@ java_version=$(curl -Ls "${adoptopenjdk_url}" | jq -r 'map(.version_data.openjdk
 # Make sure we end up with a valid VHD name
 java_version=${java_version//+/_}
 
-subscription_id=$(az account show --query "id" --output tsv)
-client_id=$(az ad app list --query "[?displayName=='Packer'].appId" --output tsv)
+# Check if client_id and subscription_id where given as files or strings
+if [[ -f "$client_id" ]]; then
+  client_id=$(cat "$client_id")
+fi
+if [[ -f "$subscription_id" ]]; then
+  subscription_id=$(cat "$subscription_id")
+fi
 
 packer build \
   -var "client_id=$client_id" \


### PR DESCRIPTION
Motivation:

- Azure CLI looks broken in CI environment and shouldn't be used

Modifications:

- Added two parameters for client and subscription ids
- Check if they are files or actually strings in order to cat the content if needed