### PR TITLE
Add manifest post-processor to GCP certified image packer build

### DIFF
--- a/packer/template-probe-gce.json
+++ b/packer/template-probe-gce.json
@@ -20,5 +20,13 @@
       "--extra-vars", "install_path=/opt",
       "--extra-vars", "adoptopenjdk_major={{ user `java_major` }}"
     ]
-  }]
+  }],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "manifest-{{user `java-major`}}.json",
+      "strip_path": true,
+      "strip_time": true
+    }
+  ]
 }


### PR DESCRIPTION
This is used to get a reference to the name of the images that have
created, for further processing.