### PR TITLE
Migrate to AdoptOpenJDK API v3, OPS-19

### DIFF
--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -9,11 +9,11 @@
 
 - name: Filter latest version
   set_fact:
-    adoptopenjdk_directory_name: '{{ item.binary_type + item.release_name[3:] }}'
-    adoptopenjdk_archive_name: '{{ item.binary_name }}'
-    adoptopenjdk_archive_url: '{{ item.binary_link }}'
-    adoptopenjdk_checksum_url: '{{ item.checksum_link }}'
-  with_items: '{{ (adoptopenjdk_api_response.content | default("{}")) | from_json | json_query(adoptopenjdk_api_query) }}'
+    adoptopenjdk_directory_name: '{{ item.binary.image_type + item.release_name[3:] }}'
+    adoptopenjdk_archive_name: '{{ item.binary.package.name }}'
+    adoptopenjdk_archive_url: '{{ item.binary.package.link }}'
+    adoptopenjdk_checksum: '{{ item.binary.package.checksum }}'
+  with_items: '{{ (adoptopenjdk_api_response.content | default("[]")) | from_json | json_query(adoptopenjdk_api_query) }}'
   when: adoptopenjdk_api_response.content is defined
 
 - name: Checking if archive already present
@@ -28,7 +28,7 @@
   get_url:
     url: '{{ adoptopenjdk_archive_url }}'
     dest: '{{ install_path }}/{{ adoptopenjdk_archive_name }}'
-    checksum: 'sha256:{{ lookup("url", adoptopenjdk_checksum_url).split(" ")[0] }}'
+    checksum: 'sha256:{{ adoptopenjdk_checksum }}'
   when: adoptopenjdk_directory.stat.exists is defined and not adoptopenjdk_directory.stat.exists and adoptopenjdk_archive.stat.exists is defined and not adoptopenjdk_archive.stat.exists
   register: adoptopenjdk_downloaded
 

--- a/roles/java/vars/main.yml
+++ b/roles/java/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 
-adoptopenjdk_api_url: 'https://api.adoptopenjdk.net/v2/latestAssets/releases/openjdk{{ adoptopenjdk_major }}?release=latest&openjdk_impl=hotspot'
-adoptopenjdk_api_query: '[?os == `linux` && architecture == `x64` && binary_type == `{{java.type}}`]'
+adoptopenjdk_api_url: 'https://api.adoptopenjdk.net/v3/assets/latest/{{ adoptopenjdk_major }}/hotspot'
+adoptopenjdk_api_query: '[?binary.os == `linux` && binary.architecture == `x64` && binary.image_type == `{{ java.type }}`]'


### PR DESCRIPTION
Motivation:

- v2 is deprecated and migrating to v3 is encouraged
- v2 randomly 404 for no reason at all

Modification:

- Updated the payload inspection
- Removed the checksum link lookup as in v3 the checksum is directly accessible from within the payload

Result:

- Installer will now get AdoptOpenJDK release informations using API v3