### PR TITLE
Switch to Adoptium, close FL-821

### DIFF
--- a/packer/build-probe-aws.sh
+++ b/packer/build-probe-aws.sh
@@ -8,8 +8,12 @@ java_major="$3"
 
 copy_regions=$(aws --profile "$profile" ec2 describe-regions --query "Regions[?RegionName != '$build_region'].RegionName" --output text | tr -s '[:blank:]' ',')
 
-adoptopenjdk_url="https://api.adoptopenjdk.net/v2/latestAssets/releases/openjdk${java_major}?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk"
-java_version=$(curl -Ls "${adoptopenjdk_url}" | jq -r 'map(.version_data.openjdk_version) | .[]')
+adoptopenjdk_url="https://api.adoptium.net/v3/assets/latest/${java_major}/hotspot"
+java_version=$(curl -Ls "${adoptopenjdk_url}" | jq -r '.[] | select(
+    (.binary.os == "linux") and
+    (.binary.architecture == "x64") and
+    (.binary.image_type == "jdk")
+  ) | .version.openjdk_version')
 
 packer build \
   -var "profile=$profile" \

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -4,7 +4,6 @@
   uri:
     url: '{{ adoptopenjdk_api_url }}'
     return_content: True
-    body_format: json
   register: adoptopenjdk_api_response
 
 - name: Filter latest version
@@ -13,7 +12,7 @@
     adoptopenjdk_archive_name: '{{ item.binary.package.name }}'
     adoptopenjdk_archive_url: '{{ item.binary.package.link }}'
     adoptopenjdk_checksum: '{{ item.binary.package.checksum }}'
-  with_items: '{{ (adoptopenjdk_api_response.content | default("[]")) | from_json | json_query(adoptopenjdk_api_query) }}'
+  with_items: '{{ adoptopenjdk_api_response.json | json_query(adoptopenjdk_api_query) }}'
   when: adoptopenjdk_api_response.content is defined
 
 - name: Checking if archive already present

--- a/roles/java/vars/main.yml
+++ b/roles/java/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 
-adoptopenjdk_api_url: 'https://api.adoptopenjdk.net/v3/assets/latest/{{ adoptopenjdk_major }}/hotspot'
+adoptopenjdk_api_url: 'https://api.adoptium.net/v3/assets/latest/{{ adoptopenjdk_major }}/hotspot'
 adoptopenjdk_api_query: '[?binary.os == `linux` && binary.architecture == `x64` && binary.image_type == `{{ java.type }}`]'


### PR DESCRIPTION
Motivation:

- AdoptOpenJDK is being superseded by Adoptium

Modification:

- Using only v3
- Removed body_format as it only applies to request body and there isn't
  any
- Used .json instead of .content so we don't have to do any weird
  conversion