### PR TITLE
chore: ship a simple JRE without CRaC, close OPS-157

### DIFF
--- a/lib/java-latest-version.sh
+++ b/lib/java-latest-version.sh
@@ -5,10 +5,8 @@ set -eu
 default_bundle="jre"
 java_major="$1"
 arch="$2"
-bundle_type="${3:-$default_bundle}"
 
-
-zulu_url="https://api.azul.com/zulu/download/community/v1.0/bundles/?os=linux&jdk_version=${java_major}&arch=${arch}&hw_bitness=64&ext=tar.gz&bundle_type=${bundle_type}&latest=true&javafx=false"
+zulu_url="https://api.azul.com/metadata/v1/zulu/packages/?java_version=${java_major}&os=linux-glibc&arch=${arch}&archive_type=tar.gz&java_package_type=jre&javafx_bundled=false&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck"
 
 zulu_output=$(curl -Lfs "${zulu_url}")
 exit_code=$?


### PR DESCRIPTION
Motivations:

* we're using the old deprecated Zulu API
* this old API lacks some filters. The existing API call fetches also CRaC builds and they appear first in the results list so we're picking it instead of a simple JRE.
* the third parameter is unused