### PR TITLE
chore: add crs_supported=true filter to only return 1 result

### DIFF
--- a/lib/java-latest-version.sh
+++ b/lib/java-latest-version.sh
@@ -6,7 +6,7 @@ default_bundle="jre"
 java_major="$1"
 arch="$2"
 
-zulu_url="https://api.azul.com/metadata/v1/zulu/packages/?java_version=${java_major}&os=linux-glibc&arch=${arch}&archive_type=tar.gz&java_package_type=jre&javafx_bundled=false&crac_supported=false&latest=true&release_status=ga&availability_types=CA&certifications=tck"
+zulu_url="https://api.azul.com/metadata/v1/zulu/packages/?java_version=${java_major}&os=linux-glibc&arch=${arch}&archive_type=tar.gz&java_package_type=jre&javafx_bundled=false&crac_supported=false&crs_supported=true&latest=true&release_status=ga&availability_types=CA&certifications=tck"
 
 zulu_output=$(curl -Lfs "${zulu_url}")
 exit_code=$?


### PR DESCRIPTION
Motivation:

`latest=true` doesn't guarantee a unique result but only the latest version of each flavor. For example, requesting Java 21 returns 2 results:
* 21.0.7 that supports CRS
* 21.0.1 that doesn't

Setting a `crs_supported=true` filter guarantees we only get 1 result and don't risk fetching the wrong one.