### PR TITLE
Exclude me-south-1 region

### DIFF
--- a/build-aws-arm-graal.sh
+++ b/build-aws-arm-graal.sh
@@ -60,7 +60,7 @@ function run
 	copy_regions_list="[]"
 	if [ $copy_regions == "true" ]
 	then
-    copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ')
+    copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ' | grep -v me-south-1)
 	  log info "Copy regions: $copy_regions_list"
 	fi
 

--- a/build-aws-arm-zulu.sh
+++ b/build-aws-arm-zulu.sh
@@ -59,7 +59,7 @@ function run
 	copy_regions_list="[]"
 	if [ $copy_regions == "true" ]
 	then
-          copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ')
+          copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ' | grep -v me-south-1 )
 	  log info "Copy regions: $copy_regions_list"
 	fi
 

--- a/build-aws-x86-graal.sh
+++ b/build-aws-x86-graal.sh
@@ -61,7 +61,7 @@ function run
 	copy_regions_list="[]"
 	if [ $copy_regions == "true" ]
 	then
-    copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ')
+    copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ' | grep -v me-south-1)
 	  log info "Copy regions: $copy_regions_list"
 	fi
 

--- a/build-aws-x86-zulu.sh
+++ b/build-aws-x86-zulu.sh
@@ -60,7 +60,7 @@ function run
 	copy_regions_list="[]"
 	if [ $copy_regions == "true" ]
 	then
-    copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ')
+    copy_regions_list=$($AWS_CLI ec2 describe-regions --region=eu-west-3 --query "Regions[?RegionName != 'eu-west-3'].RegionName" --output json | tr -s '[:blank:]' ' ' | grep -v me-south-1 )
 	  log info "Copy regions: $copy_regions_list"
 	fi
 


### PR DESCRIPTION
Motivation:
Because of Trump, a drone crashed onto the me-south-1 data center. This data center is therefore unavailable and is blocking the publication of our image. We must therefore exclude it.

Modifications:
Added exclusion for follwing file :  
 -  build-aws-arm-graal.sh
 -  build-aws-arm-zulu.sh
 -  build-aws-x86-graal.sh
 -  build-aws-x86-zulu.sh
 