### PR TITLE
Update graal version &  Fix graal chains for GraalVM's new 'inovative' version numbering

### DIFF
--- a/.github/workflows/aws-arm-graal-latest.yml
+++ b/.github/workflows/aws-arm-graal-latest.yml
@@ -29,10 +29,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_SELLER }}
           aws-region: eu-west-3
 
-
       - name: Build image from template
         run: cd packer; packer init aws-arm-graal.pkr.hcl
 
-
       - name: Build image from template
-        run: ./build-aws-arm-graal.sh --java-major 25 --graalvm-version 25.0.2 --copy-regions true --profile default --latest true
+        run: ./build-aws-arm-graal.sh --java-major 25 --graalvm-version 25.2.4  --javavm-version 25i2-25.0.4  --copy-regions true --profile default --latest true

--- a/.github/workflows/aws-arm-graal-latest.yml
+++ b/.github/workflows/aws-arm-graal-latest.yml
@@ -33,4 +33,4 @@ jobs:
         run: cd packer; packer init aws-arm-graal.pkr.hcl
 
       - name: Build image from template
-        run: ./build-aws-arm-graal.sh --java-major 25 --graalvm-version 25.2.4  --javavm-version 25i2-25.0.4  --copy-regions true --profile default --latest true
+        run: ./build-aws-arm-graal.sh --java-major 25 --graalvm-jdk-tag 25.2.4  --graalvm-jdk-version 25i2-25.0.4  --copy-regions true --profile default --latest true

--- a/.github/workflows/aws-x86-graal-latest.yml
+++ b/.github/workflows/aws-x86-graal-latest.yml
@@ -33,4 +33,4 @@ jobs:
         run: cd packer; packer init aws-x86-graal.pkr.hcl
 
       - name: Build image from template
-        run: ./build-aws-x86-graal.sh --java-major 25 --graalvm-version 25.0.2 --copy-regions true --profile default --latest true
+        run: ./build-aws-x86-graal.sh --java-major 25 --graalvm-version 25.2.4  --javavm-version 25i2-25.0.4  --copy-regions true --profile default --latest true

--- a/.github/workflows/aws-x86-graal-latest.yml
+++ b/.github/workflows/aws-x86-graal-latest.yml
@@ -33,4 +33,4 @@ jobs:
         run: cd packer; packer init aws-x86-graal.pkr.hcl
 
       - name: Build image from template
-        run: ./build-aws-x86-graal.sh --java-major 25 --graalvm-version 25.2.4  --javavm-version 25i2-25.0.4  --copy-regions true --profile default --latest true
+        run: ./build-aws-x86-graal.sh --java-major 25 --graalvm-jdk-tag 25.2.4  --graalvm-jdk-version 25i2-25.0.4  --copy-regions true --profile default --latest true

--- a/.github/workflows/azure-x86-graal-latest.yml
+++ b/.github/workflows/azure-x86-graal-latest.yml
@@ -35,7 +35,8 @@ jobs:
         run: |
           ./build-azure-x86-graal.sh \
             --java-major 25 \
-            --graalvm-version 25.0.2 \
+            --graalvm-version 25.2.4  \
+            --javavm-version 25i2-25.0.4 \
             --client-id "$CLIENT_ID" \
             --client-secret "$CLIENT_SECRET" \
             --subscription-id "$SUBSCRIPTION_ID" \

--- a/.github/workflows/azure-x86-graal-latest.yml
+++ b/.github/workflows/azure-x86-graal-latest.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           ./build-azure-x86-graal.sh \
             --java-major 25 \
-            --graalvm-version 25.2.4  \
-            --javavm-version 25i2-25.0.4 \
+            --graalvm-jdk-tag 25.2.4  \
+            --graalvm-jdk-version 25i2-25.0.4 \
             --client-id "$CLIENT_ID" \
             --client-secret "$CLIENT_SECRET" \
             --subscription-id "$SUBSCRIPTION_ID" \

--- a/.github/workflows/gcp-x86-graal-latest.yml
+++ b/.github/workflows/gcp-x86-graal-latest.yml
@@ -34,4 +34,4 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: "./creds.json"
           GOOGLE_PROJECT_ID: ${{ secrets.GOOGLE_PROJECT_ID }}
         run: |
-          ./build-gcp-x86-graal.sh --java-major 25 --graalvm-version 25.2.4  --javavm-version 25i2-25.0.4 --project-id "$GOOGLE_PROJECT_ID"  --latest true
+          ./build-gcp-x86-graal.sh --java-major 25 --graalvm-jdk-tag 25.2.4  --graalvm-jdk-version 25i2-25.0.4 --project-id "$GOOGLE_PROJECT_ID"  --latest true

--- a/.github/workflows/gcp-x86-graal-latest.yml
+++ b/.github/workflows/gcp-x86-graal-latest.yml
@@ -19,10 +19,8 @@ jobs:
         with:
             packer-version: '1.11.2'
 
-
       - name: Build image from template
         run: cd packer; packer init gcp-x86-graal.pkr.hcl
-
 
       - name: Configure GCP Credentials
         run: |
@@ -36,4 +34,4 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: "./creds.json"
           GOOGLE_PROJECT_ID: ${{ secrets.GOOGLE_PROJECT_ID }}
         run: |
-          ./build-gcp-x86-graal.sh --java-major 25  --graalvm-version 25.0.2  --project-id "$GOOGLE_PROJECT_ID"  --latest true
+          ./build-gcp-x86-graal.sh --java-major 25 --graalvm-version 25.2.4  --javavm-version 25i2-25.0.4 --project-id "$GOOGLE_PROJECT_ID"  --latest true

--- a/build-aws-arm-graal.sh
+++ b/build-aws-arm-graal.sh
@@ -8,9 +8,10 @@ AWS_CLI=$(which aws)
 
 function usage
 {
-    echo "usage: $0 --java-major MAJOR --graalvm-version VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
+    echo "usage: $0 --java-major MAJOR  --javavm-version VERSION --graalvm-version VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
     echo "   ";
     echo "  --java-major        : Java major version";
+    echo "  --javavm-version    : Java version with inovative number and minor";
     echo "  --graalvm-version    : Graalvm version with minor";
     echo "  --copy-regions      : true or false";
     echo "  --profile           : AWS Profile";
@@ -28,6 +29,7 @@ function parse_args
       case "$1" in
           --java-major )         java_major="$2";       shift;;
           --graalvm-version )    graalvm_version="$2";       shift;;
+          --javavm-version )     javavm_version="$2";   shift;;
           --copy-regions )       copy_regions="$2";     shift;;
           --profile )            aws_profile="$2";      shift;;
           --latest )             latest="$2";           shift;;
@@ -38,7 +40,7 @@ function parse_args
   done
 
   # Validate required args
-  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_version}" ]]; then
+  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_version}" || -z "${javavm_version}"  ]]; then
       echo "Invalid arguments"
       usage
       exit;
@@ -82,6 +84,7 @@ function run
 	  -var "build_id=$build_id" \
 	  -var "java_major=$java_major" \
 	  -var "graalvm_version=$graalvm_version" \
+	  -var "javavm_version=$javavm_version" \
 	  -var "copy_regions=$copy_regions_list" \
 	  -var "ami_description=$ami_description" \
 	  packer/aws-arm-graal.pkr.hcl

--- a/build-aws-arm-graal.sh
+++ b/build-aws-arm-graal.sh
@@ -8,15 +8,15 @@ AWS_CLI=$(which aws)
 
 function usage
 {
-    echo "usage: $0 --java-major MAJOR  --javavm-version VERSION --graalvm-version VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
+    echo "usage: $0 --java-major MAJOR  --graalvm-jdk-version VERSION --graalvm-jdk-tag VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
     echo "   ";
-    echo "  --java-major        : Java major version";
-    echo "  --javavm-version    : Java version with inovative number and minor";
-    echo "  --graalvm-version    : Graalvm version with minor";
-    echo "  --copy-regions      : true or false";
-    echo "  --profile           : AWS Profile";
-    echo "  --latest            : Want latest ?";
-    echo "  --help              : This message";
+    echo "  --java-major             : Java major version";
+    echo "  --graalvm-jdk-version    : Graalvm jdk version with inovative number and minor";
+    echo "  --graalvm-jdk-tag        : Graalvm jdk version tag";
+    echo "  --copy-regions           : true or false";
+    echo "  --profile                : AWS Profile";
+    echo "  --latest                 : Want latest ?";
+    echo "  --help                   : This message";
 }
 
 function parse_args
@@ -27,20 +27,20 @@ function parse_args
   # named args
   while [ "$1" != "" ]; do
       case "$1" in
-          --java-major )         java_major="$2";       shift;;
-          --graalvm-version )    graalvm_version="$2";       shift;;
-          --javavm-version )     javavm_version="$2";   shift;;
-          --copy-regions )       copy_regions="$2";     shift;;
-          --profile )            aws_profile="$2";      shift;;
-          --latest )             latest="$2";           shift;;
-          --help )               usage;                 exit;; # quit and show usage
-          * )                    args+=("$1")           # if no match, add it to the positional args
+          --java-major )                java_major="$2";       shift;;
+          --graalvm-jdk-tag )           graalvm_jdk_tag="$2";       shift;;
+          --graalvm-jdk-version )       graalvm_jdk_version="$2";   shift;;
+          --copy-regions )              copy_regions="$2";     shift;;
+          --profile )                   aws_profile="$2";      shift;;
+          --latest )                    latest="$2";           shift;;
+          --help )                      usage;                 exit;; # quit and show usage
+          * )                           args+=("$1")           # if no match, add it to the positional args
       esac
       shift # move to next kv pair
   done
 
   # Validate required args
-  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_version}" || -z "${javavm_version}"  ]]; then
+  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_jdk_tag}" || -z "${graalvm_jdk_version}"  ]]; then
       echo "Invalid arguments"
       usage
       exit;
@@ -83,8 +83,8 @@ function run
 	  -var "aws_profile=$aws_profile" \
 	  -var "build_id=$build_id" \
 	  -var "java_major=$java_major" \
-	  -var "graalvm_version=$graalvm_version" \
-	  -var "javavm_version=$javavm_version" \
+	  -var "graalvm_jdk_tag=$graalvm_jdk_tag" \
+	  -var "graalvm_jdk_version=$graalvm_jdk_version" \
 	  -var "copy_regions=$copy_regions_list" \
 	  -var "ami_description=$ami_description" \
 	  packer/aws-arm-graal.pkr.hcl

--- a/build-aws-x86-graal.sh
+++ b/build-aws-x86-graal.sh
@@ -8,10 +8,11 @@ AWS_CLI=$(which aws)
 
 function usage
 {
-    echo "usage: $0 --java-major MAJOR --graalvm-version VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
+    echo "usage: $0 --java-major MAJOR  --javavm-version VERSION --graalvm-version VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
     echo "   ";
     echo "  --java-major        : Java major version";
     echo "  --graalvm-version    : Graalvm version with minor";
+    echo "  --javavm-version    : Java version with inovative number and minor";
     echo "  --copy-regions      : true or false";
     echo "  --profile           : AWS Profile";
     echo "  --latest            : Want latest ?";
@@ -28,6 +29,7 @@ function parse_args
       case "$1" in
           --java-major )         java_major="$2";       shift;;
           --graalvm-version )    graalvm_version="$2";  shift;;
+          --javavm-version )     javavm_version="$2";   shift;;
           --copy-regions )       copy_regions="$2";     shift;;
           --profile )            aws_profile="$2";      shift;;
           --latest )             latest="$2";           shift;;
@@ -38,7 +40,7 @@ function parse_args
   done
 
   # Validate required args
-  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_version}"  ]]; then
+  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_version}" || -z "${javavm_version}"  ]]; then
       echo "Invalid arguments"
       usage
       exit 1;
@@ -48,7 +50,6 @@ function parse_args
 
 function run
 {
-
   parse_args "$@"
 
   . lib/log.sh
@@ -83,10 +84,10 @@ function run
 	  -var "build_id=$build_id" \
 	  -var "java_major=$java_major" \
 	  -var "graalvm_version=$graalvm_version" \
+	  -var "javavm_version=$javavm_version" \
 	  -var "copy_regions=$copy_regions_list" \
 	  -var "ami_description=$ami_description" \
 	  packer/aws-x86-graal.pkr.hcl
 }
-
 
 run "$@";

--- a/build-aws-x86-graal.sh
+++ b/build-aws-x86-graal.sh
@@ -8,15 +8,15 @@ AWS_CLI=$(which aws)
 
 function usage
 {
-    echo "usage: $0 --java-major MAJOR  --javavm-version VERSION --graalvm-version VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
+    echo "usage: $0 --java-major MAJOR  --graalvm-jdk-version VERSION --graalvm-jdk-tag VERSION --copy-regions [true|false] --profile AWS_PROFILE --latest [true|false] [--help]"
     echo "   ";
-    echo "  --java-major        : Java major version";
-    echo "  --graalvm-version    : Graalvm version with minor";
-    echo "  --javavm-version    : Java version with inovative number and minor";
-    echo "  --copy-regions      : true or false";
-    echo "  --profile           : AWS Profile";
-    echo "  --latest            : Want latest ?";
-    echo "  --help              : This message";
+    echo "  --java-major             : Java major version";
+    echo "  --graalvm-jdk-version    : Graalvm jdk version with inovative number and minor";
+    echo "  --graalvm-jdk-tag        : Graalvm jdk version tag";
+    echo "  --copy-regions           : true or false";
+    echo "  --profile                : AWS Profile";
+    echo "  --latest                 : Want latest ?";
+    echo "  --help                   : This message";
 }
 
 function parse_args
@@ -27,20 +27,20 @@ function parse_args
   # named args
   while [ "$1" != "" ]; do
       case "$1" in
-          --java-major )         java_major="$2";       shift;;
-          --graalvm-version )    graalvm_version="$2";  shift;;
-          --javavm-version )     javavm_version="$2";   shift;;
-          --copy-regions )       copy_regions="$2";     shift;;
-          --profile )            aws_profile="$2";      shift;;
-          --latest )             latest="$2";           shift;;
-          --help )               usage;                 exit;; # quit and show usage
-          * )                    args+=("$1")           # if no match, add it to the positional args
+          --java-major )              java_major="$2";       shift;;
+          --graalvm-jdk-tag )         graalvm_jdk_tag="$2";  shift;;
+          --graalvm-jdk-version )     graalvm_jdk_version="$2";   shift;;
+          --copy-regions )            copy_regions="$2";     shift;;
+          --profile )                 aws_profile="$2";      shift;;
+          --latest )                  latest="$2";           shift;;
+          --help )                    usage;                 exit;; # quit and show usage
+          * )                         args+=("$1")           # if no match, add it to the positional args
       esac
       shift # move to next kv pair
   done
 
   # Validate required args
-  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_version}" || -z "${javavm_version}"  ]]; then
+  if [[ -z "${java_major}" || -z "${copy_regions}" || -z "${aws_profile}" || -z "${latest}" || -z "${graalvm_jdk_tag}" || -z "${graalvm_jdk_version}"  ]]; then
       echo "Invalid arguments"
       usage
       exit 1;
@@ -83,8 +83,8 @@ function run
 	  -var "aws_profile=$aws_profile" \
 	  -var "build_id=$build_id" \
 	  -var "java_major=$java_major" \
-	  -var "graalvm_version=$graalvm_version" \
-	  -var "javavm_version=$javavm_version" \
+	  -var "graalvm_jdk_tag=$graalvm_jdk_tag" \
+	  -var "graalvm_jdk_version=$graalvm_jdk_version" \
 	  -var "copy_regions=$copy_regions_list" \
 	  -var "ami_description=$ami_description" \
 	  packer/aws-x86-graal.pkr.hcl

--- a/build-azure-x86-graal.sh
+++ b/build-azure-x86-graal.sh
@@ -31,7 +31,7 @@ function parse_args
       case "$1" in
           --java-major )         java_major="$2";       shift;;
           --javavm-version )     javavm_version="$2";   shift;;
-          --graalvm-version )    graalvm_version="$2";       shift;;
+          --graalvm-version )    graalvm_version="$2";  shift;;
           --client-id )          client_id="$2";        shift;;
           --client-secret )      client_secret="$2";    shift;;
           --subscription-id )    subscription_id="$2";  shift;;

--- a/build-azure-x86-graal.sh
+++ b/build-azure-x86-graal.sh
@@ -8,17 +8,17 @@ PACKER=$(which packer)
 
 function usage
 {
-    echo "usage: $0  --java-major MAJOR --javavm-version VERSION --graalvm-version VERSION --client-id CLIENT_ID --client-secret CLIENT_SECRET --subscription-id SUBSCRIPTION_ID --tenand-id TENANT_ID --image-version IMAGE_VERSION [--help]"
+    echo "usage: $0  --java-major MAJOR --graalvm-jdk-version VERSION --graalvm-jdk-tag VERSION --client-id CLIENT_ID --client-secret CLIENT_SECRET --subscription-id SUBSCRIPTION_ID --tenand-id TENANT_ID --image-version IMAGE_VERSION [--help]"
     echo "   ";
-    echo "  --java-major        : Java major version";
-    echo "  --graalvm-version    : Graalvm version with minor";
-    echo "  --javavm-version    : Java version with inovative number and minor";
-    echo "  --client-id         : Azure Client ID";
-    echo "  --client-secret     : Azure Client Secret";
-    echo "  --subscription-id   : Azure Subscription ID";
-    echo "  --tenant-id         : Azure Tenant ID";
-    echo "  --image-version     : Azure Image Version";
-    echo "  --help              : This message";
+    echo "  --java-major             : Java major version";
+    echo "  --graalvm-jdk-version    : Graalvm jdk version with inovative number and minor";
+    echo "  --graalvm-jdk-tag        : Graalvm jdk version tag";
+    echo "  --client-id              : Azure Client ID";
+    echo "  --client-secret          : Azure Client Secret";
+    echo "  --subscription-id        : Azure Subscription ID";
+    echo "  --tenant-id              : Azure Tenant ID";
+    echo "  --image-version          : Azure Image Version";
+    echo "  --help                   : This message";
 }
 
 function parse_args
@@ -30,8 +30,8 @@ function parse_args
   while [ "$1" != "" ]; do
       case "$1" in
           --java-major )         java_major="$2";       shift;;
-          --javavm-version )     javavm_version="$2";   shift;;
-          --graalvm-version )    graalvm_version="$2";  shift;;
+          --graalvm-jdk-version )     graalvm_jdk_version="$2";   shift;;
+          --graalvm-jdk-tag )    graalvm_jdk_tag="$2";  shift;;
           --client-id )          client_id="$2";        shift;;
           --client-secret )      client_secret="$2";    shift;;
           --subscription-id )    subscription_id="$2";  shift;;
@@ -44,7 +44,7 @@ function parse_args
   done
 
   # Validate required args
-    if [[ -z "${java_major}" || -z "${client_id}" || -z "${client_secret}" || -z "${subscription_id}" || -z "${tenant_id}" || -z "${image_version}" || -z "${graalvm_version}" || -z "${javavm_version}" ]]; then
+    if [[ -z "${java_major}" || -z "${client_id}" || -z "${client_secret}" || -z "${subscription_id}" || -z "${tenant_id}" || -z "${image_version}" || -z "${graalvm_jdk_tag}" || -z "${graalvm_jdk_version}" ]]; then
       echo "Invalid arguments"
       usage
       exit
@@ -64,15 +64,15 @@ function run
 
   log info "Build Gatling Enterprise Injector x86_64 (build_id: $build_id)"
 	log info "Image version: $image_version"
-  log info "OpenJDK version: $graalvm_version"
+  log info "OpenJDK version: $graalvm_jdk_tag"
   log info "Client ID: ${client_id} "
   log info "Subscription ID: ${subscription_id} "
   log info "Tenant ID: ${tenant_id} "
 
 	$PACKER build \
 	  -var "java_major=$java_major" \
-	  -var "graalvm_version=$graalvm_version" \
-	  -var "javavm_version=$javavm_version" \
+	  -var "graalvm_jdk_tag=$graalvm_jdk_tag" \
+	  -var "graalvm_jdk_version=$graalvm_jdk_version" \
 	  -var "client_id=$client_id" \
 	  -var "client_secret=$client_secret" \
 	  -var "subscription_id=$subscription_id" \

--- a/build-azure-x86-graal.sh
+++ b/build-azure-x86-graal.sh
@@ -8,10 +8,11 @@ PACKER=$(which packer)
 
 function usage
 {
-    echo "usage: $0  --java-major MAJOR --graalvm-version VERSION --client-id CLIENT_ID --client-secret CLIENT_SECRET --subscription-id SUBSCRIPTION_ID --tenand-id TENANT_ID --image-version IMAGE_VERSION [--help]"
+    echo "usage: $0  --java-major MAJOR --javavm-version VERSION --graalvm-version VERSION --client-id CLIENT_ID --client-secret CLIENT_SECRET --subscription-id SUBSCRIPTION_ID --tenand-id TENANT_ID --image-version IMAGE_VERSION [--help]"
     echo "   ";
     echo "  --java-major        : Java major version";
     echo "  --graalvm-version    : Graalvm version with minor";
+    echo "  --javavm-version    : Java version with inovative number and minor";
     echo "  --client-id         : Azure Client ID";
     echo "  --client-secret     : Azure Client Secret";
     echo "  --subscription-id   : Azure Subscription ID";
@@ -29,6 +30,7 @@ function parse_args
   while [ "$1" != "" ]; do
       case "$1" in
           --java-major )         java_major="$2";       shift;;
+          --javavm-version )     javavm_version="$2";   shift;;
           --graalvm-version )    graalvm_version="$2";       shift;;
           --client-id )          client_id="$2";        shift;;
           --client-secret )      client_secret="$2";    shift;;
@@ -42,7 +44,7 @@ function parse_args
   done
 
   # Validate required args
-  if [[ -z "${java_major}" || -z "${client_id}" || -z "${client_secret}" || -z "${subscription_id}" || -z "${tenant_id}" || -z "${image_version}" || -z "${graalvm_version}" ]]; then
+    if [[ -z "${java_major}" || -z "${client_id}" || -z "${client_secret}" || -z "${subscription_id}" || -z "${tenant_id}" || -z "${image_version}" || -z "${graalvm_version}" || -z "${javavm_version}" ]]; then
       echo "Invalid arguments"
       usage
       exit
@@ -70,6 +72,7 @@ function run
 	$PACKER build \
 	  -var "java_major=$java_major" \
 	  -var "graalvm_version=$graalvm_version" \
+	  -var "javavm_version=$javavm_version" \
 	  -var "client_id=$client_id" \
 	  -var "client_secret=$client_secret" \
 	  -var "subscription_id=$subscription_id" \

--- a/build-gcp-x86-graal.sh
+++ b/build-gcp-x86-graal.sh
@@ -8,10 +8,11 @@ GCP_CLI=$(which gcloud)
 
 function usage
 {
-    echo "usage: $0  --java-major MAJOR  --graalvm-version VERSION --project-id PROJECT_ID --latest [true|false] [--help]"
+    echo "usage: $0  --java-major MAJOR --javavm-version VERSION  --graalvm-version VERSION --project-id PROJECT_ID --latest [true|false] [--help]"
     echo "   ";
     echo "  --java-major        : Java major version";
     echo "  --graalvm-version    : Graalvm version with minor";
+    echo "  --javavm-version    : Java version with inovative number and minor";
     echo "  --project-id        : GCP project id";
     echo "  --latest            : Want latest ?";
     echo "  --help              : This message";
@@ -25,7 +26,8 @@ function parse_args
   # named args
   while [ "$1" != "" ]; do
       case "$1" in
-          --graalvm-version )    graalvm_version="$2";       shift;;
+          --graalvm-version )    graalvm_version="$2";  shift;;
+          --javavm-version )     javavm_version="$2";   shift;;
           --java-major )         java_major="$2";       shift;;
           --project-id )         project_id="$2";       shift;;
           --latest )             latest="$2";           shift;;
@@ -36,10 +38,10 @@ function parse_args
   done
 
   # Validate required args
-  if [[ -z "${java_major}" || -z "${project_id}" || -z "${latest}" || -z "${graalvm_version}" ]]; then
+  if [[ -z "${java_major}" || -z "${project_id}" || -z "${latest}" || -z "${graalvm_version}" || -z "${javavm_version}" ]]; then
       echo "Invalid arguments"
       usage
-      exit;
+      exit 1;
   fi
 
 }
@@ -75,6 +77,7 @@ function run
   ${PACKER} build \
    -var "java_major=$java_major" \
    -var "graalvm_version=$graalvm_version" \
+   -var "javavm_version=$javavm_version" \
    -var "project_id=$project_id" \
    -var "build_id=$build_id" \
    -var "image_name=$image_name" \

--- a/build-gcp-x86-graal.sh
+++ b/build-gcp-x86-graal.sh
@@ -8,14 +8,14 @@ GCP_CLI=$(which gcloud)
 
 function usage
 {
-    echo "usage: $0  --java-major MAJOR --javavm-version VERSION  --graalvm-version VERSION --project-id PROJECT_ID --latest [true|false] [--help]"
+    echo "usage: $0  --java-major MAJOR --graalvm-jdk-version VERSION  --graalvm-jdk-tag VERSION --project-id PROJECT_ID --latest [true|false] [--help]"
     echo "   ";
-    echo "  --java-major        : Java major version";
-    echo "  --graalvm-version    : Graalvm version with minor";
-    echo "  --javavm-version    : Java version with inovative number and minor";
-    echo "  --project-id        : GCP project id";
-    echo "  --latest            : Want latest ?";
-    echo "  --help              : This message";
+    echo "  --java-major             : Java major version";
+    echo "  --graalvm-jdk-version    : Graalvm jdk version with inovative number and minor";
+    echo "  --graalvm-jdk-tag        : Graalvm jdk version tag";
+    echo "  --project-id             : GCP project id";
+    echo "  --latest                 : Want latest ?";
+    echo "  --help                   : This message";
 }
 
 function parse_args
@@ -26,19 +26,19 @@ function parse_args
   # named args
   while [ "$1" != "" ]; do
       case "$1" in
-          --graalvm-version )    graalvm_version="$2";  shift;;
-          --javavm-version )     javavm_version="$2";   shift;;
-          --java-major )         java_major="$2";       shift;;
-          --project-id )         project_id="$2";       shift;;
-          --latest )             latest="$2";           shift;;
-          --help )               usage;                 exit;; # quit and show usage
-          * )                    args+=("$1")           # if no match, add it to the positional args
+          --graalvm-jdk-tag )         graalvm_jdk_tag="$2";  shift;;
+          --graalvm-jdk-version )     graalvm_jdk_version="$2";   shift;;
+          --java-major )              java_major="$2";       shift;;
+          --project-id )              project_id="$2";       shift;;
+          --latest )                  latest="$2";           shift;;
+          --help )                    usage;                 exit;; # quit and show usage
+          * )                         args+=("$1")           # if no match, add it to the positional args
       esac
       shift # move to next kv pair
   done
 
   # Validate required args
-  if [[ -z "${java_major}" || -z "${project_id}" || -z "${latest}" || -z "${graalvm_version}" || -z "${javavm_version}" ]]; then
+  if [[ -z "${java_major}" || -z "${project_id}" || -z "${latest}" || -z "${graalvm_jdk_tag}" || -z "${graalvm_jdk_version}" ]]; then
       echo "Invalid arguments"
       usage
       exit 1;
@@ -57,7 +57,7 @@ function run
 
   log info "Build Gatling Enterprise Injector x86_64 (build_id: $build_id)"
   log info "Project ID: ${project_id} "
-  log info "OpenJDK version: $graalvm_version"
+  log info "OpenJDK version: $graalvm_jdk_tag"
 
 
   image_name="graalvm-openjdk-${java_major}-${build_id}"
@@ -76,8 +76,8 @@ function run
 
   ${PACKER} build \
    -var "java_major=$java_major" \
-   -var "graalvm_version=$graalvm_version" \
-   -var "javavm_version=$javavm_version" \
+   -var "graalvm_jdk_tag=$graalvm_jdk_tag" \
+   -var "graalvm_jdk_version=$graalvm_jdk_version" \
    -var "project_id=$project_id" \
    -var "build_id=$build_id" \
    -var "image_name=$image_name" \

--- a/packer/aws-arm-graal.pkr.hcl
+++ b/packer/aws-arm-graal.pkr.hcl
@@ -15,7 +15,11 @@ variable "java_major" {
   type = string
 }
 
-variable "graalvm_version" {
+variable "graalvm_jdk_tag" {
+  type = string
+}
+
+variable "graalvm_jdk_version" {
   type = string
 }
 
@@ -78,7 +82,7 @@ data "amazon-ami" "arm64" {
 source "amazon-ebs" "arm64" {
   ami_description  = "${var.ami_description}"
   ami_groups       = ["all"]
-  ami_name         = replace("Gatling Enterprise Injector arm64 GraalVM ${var.graalvm_version} (${var.build_id})", "+", "-")
+  ami_name         = replace("Gatling Enterprise Injector arm64 GraalVM ${var.graalvm_jdk_tag} (${var.build_id})", "+", "-")
   ami_regions      = var.copy_regions
   region           = "${var.region}"
   source_ami       = "${data.amazon-ami.arm64.id}"
@@ -92,10 +96,10 @@ source "amazon-ebs" "arm64" {
 	profile = "${var.aws_profile}"
 
   tags = {
-    Name         = replace("Gatling Enterprise Injector arm64 GraalVM ${var.graalvm_version} (${var.build_id})", "+", "-")
+    Name         = replace("Gatling Enterprise Injector arm64 GraalVM ${var.graalvm_jdk_tag} (${var.build_id})", "+", "-")
     JavaBundleType = "${var.java_bundle_type}"
     JavaVendor     = "${var.java_vendor}"
-    JavaVersion    = "${var.graalvm_version}"
+    JavaVersion    = "${var.graalvm_jdk_tag}"
     KernelVersion  = "${var.kernel_version}"
   }
    # launch_block_device_mappings {
@@ -114,7 +118,8 @@ build {
 
   provisioner "shell" {
    environment_vars = [
-     "GRAALVM_VERSION=${var.graalvm_version}",
+     "GRAALVM_JDK_TAG=${var.graalvm_jdk_tag}",
+    "GRAALVM_JDK_VERSION=${var.graalvm_jdk_version}",
     "JAVA_MAJOR=${var.java_major}",
   ]
 

--- a/packer/aws-x86-graal.pkr.hcl
+++ b/packer/aws-x86-graal.pkr.hcl
@@ -16,11 +16,11 @@ variable "java_major" {
 }
 
 
-variable "graalvm_version" {
+variable "graalvm_jdk_tag" {
   type = string
 }
 
-variable "javavm_version" {
+variable "graalvm_jdk_version" {
   type = string
 }
 
@@ -84,7 +84,7 @@ data "amazon-ami" "x86_64" {
 source "amazon-ebs" "x86_64" {
   ami_description  = "${var.ami_description}"
   ami_groups       = ["all"]
-  ami_name         = replace("Gatling Enterprise Injector x86_64 GraalVM ${var.graalvm_version} (${var.build_id})", "+", "-")
+  ami_name         = replace("Gatling Enterprise Injector x86_64 GraalVM ${var.graalvm_jdk_tag} (${var.build_id})", "+", "-")
   ami_regions      = var.copy_regions
   region           = "${var.region}"
   source_ami       = "${data.amazon-ami.x86_64.id}"
@@ -98,10 +98,10 @@ source "amazon-ebs" "x86_64" {
 	profile = "${var.aws_profile}"
 
   tags = {
-    Name         = replace("Gatling Enterprise Injector x86_64 GraalVM ${var.graalvm_version} (${var.build_id})", "+", "-")
+    Name         = replace("Gatling Enterprise Injector x86_64 GraalVM ${var.graalvm_jdk_tag} (${var.build_id})", "+", "-")
     JavaBundleType = "${var.java_bundle_type}"
     JavaVendor     = "${var.java_vendor}"
-    JavaVersion    = "${var.graalvm_version}"
+    JavaVersion    = "${var.graalvm_jdk_tag}"
     KernelVersion  = "${var.kernel_version}"
   }
 
@@ -121,8 +121,8 @@ build {
 
   provisioner "shell" {
    environment_vars = [
-    "GRAALVM_VERSION=${var.graalvm_version}",
-    "JAVAVM_VERSION=${var.javavm_version}",
+    "GRAALVM_JDK_TAG=${var.graalvm_jdk_tag}",
+    "GRAALVM_JDK_VERSION=${var.graalvm_jdk_version}",
     "JAVA_MAJOR=${var.java_major}",
   ]
 

--- a/packer/aws-x86-graal.pkr.hcl
+++ b/packer/aws-x86-graal.pkr.hcl
@@ -122,7 +122,7 @@ build {
   provisioner "shell" {
    environment_vars = [
     "GRAALVM_VERSION=${var.graalvm_version}",
-    "JAVAVM_VERSION==${var.javavm_version}",
+    "JAVAVM_VERSION=${var.javavm_version}",
     "JAVA_MAJOR=${var.java_major}",
   ]
 

--- a/packer/aws-x86-graal.pkr.hcl
+++ b/packer/aws-x86-graal.pkr.hcl
@@ -20,6 +20,10 @@ variable "graalvm_version" {
   type = string
 }
 
+variable "javavm_version" {
+  type = string
+}
+
 variable "java_bundle_type" {
   type    = string
   default = "jdk"
@@ -118,6 +122,7 @@ build {
   provisioner "shell" {
    environment_vars = [
     "GRAALVM_VERSION=${var.graalvm_version}",
+    "JAVAVM_VERSION==${var.javavm_version}",
     "JAVA_MAJOR=${var.java_major}",
   ]
 

--- a/packer/azure-x86-graal.pkr.hcl
+++ b/packer/azure-x86-graal.pkr.hcl
@@ -15,12 +15,12 @@ variable "java_major" {
   type = string
 }
 
-variable "graalvm_version" {
+variable "graalvm_jdk_tag" {
   type = string
 }
 
 
-variable "javavm_version" {
+variable "graalvm_jdk_version" {
   type = string
 }
 
@@ -104,8 +104,8 @@ build {
 
   provisioner "shell" {
    environment_vars = [
-    "GRAALVM_VERSION=${var.graalvm_version}",
-    "JAVAVM_VERSION=${var.javavm_version}",
+    "GRAALVM_JDK_TAG=${var.graalvm_jdk_tag}",
+    "GRAALVM_JDK_VERSION=${var.graalvm_jdk_version}",
     "JAVA_MAJOR=${var.java_major}",
   ]
 

--- a/packer/azure-x86-graal.pkr.hcl
+++ b/packer/azure-x86-graal.pkr.hcl
@@ -20,6 +20,10 @@ variable "graalvm_version" {
 }
 
 
+variable "javavm_version" {
+  type = string
+}
+
 variable "java_bundle_type" {
   type    = string
   default = "jre"
@@ -101,6 +105,7 @@ build {
   provisioner "shell" {
    environment_vars = [
     "GRAALVM_VERSION=${var.graalvm_version}",
+    "JAVAVM_VERSION=${var.javavm_version}",
     "JAVA_MAJOR=${var.java_major}",
   ]
 

--- a/packer/gcp-x86-graal.pkr.hcl
+++ b/packer/gcp-x86-graal.pkr.hcl
@@ -23,6 +23,10 @@ variable "graalvm_version" {
   type = string
 }
 
+variable "javavm_version" {
+  type = string
+}
+
 variable "java_bundle_type" {
   type    = string
   default = "jre"
@@ -96,6 +100,7 @@ build {
    environment_vars = [
     "GRAALVM_VERSION=${var.graalvm_version}",
     "JAVA_MAJOR=${var.java_major}",
+    "JAVAVM_VERSION=${var.javavm_version}",
   ]
 
     

--- a/packer/gcp-x86-graal.pkr.hcl
+++ b/packer/gcp-x86-graal.pkr.hcl
@@ -19,11 +19,11 @@ variable "java_major" {
   type = string
 }
 
-variable "graalvm_version" {
+variable "graalvm_jdk_tag" {
   type = string
 }
 
-variable "javavm_version" {
+variable "graalvm_jdk_version" {
   type = string
 }
 
@@ -78,7 +78,7 @@ locals {
 
 
 source "googlecompute" "x86_64" {
-  image_description       = replace("Gatling Enterprise Injector x86 OpenJDK ${var.graalvm_version} (${var.build_id})", "+", "-")
+  image_description       = replace("Gatling Enterprise Injector x86 OpenJDK ${var.graalvm_jdk_tag} (${var.build_id})", "+", "-")
   image_family            = "${var.image_family}"
   image_name              = "${var.image_name}"
   project_id              = "${var.project_id}"
@@ -98,9 +98,9 @@ build {
 
   provisioner "shell" {
    environment_vars = [
-    "GRAALVM_VERSION=${var.graalvm_version}",
+    "GRAALVM_JDK_TAG=${var.graalvm_jdk_tag}",
     "JAVA_MAJOR=${var.java_major}",
-    "JAVAVM_VERSION=${var.javavm_version}",
+    "GRAALVM_JDK_VERSION=${var.graalvm_jdk_version}",
   ]
 
     

--- a/remote-script/05-graalvm-setup-arm64.sh
+++ b/remote-script/05-graalvm-setup-arm64.sh
@@ -11,7 +11,7 @@ sudo su <<EOT
 mkdir -p /opt
 cd /opt
 
-curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_JDK_TAG}/graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-aarch64_bin.tar.gz
+curl -LO -f https://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_JDK_TAG}/graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-aarch64_bin.tar.gz
 
 tar -xzf graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-aarch64_bin.tar.gz || exit 1
 rm -f graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-aarch64_bin.tar.gz || exit 1

--- a/remote-script/05-graalvm-setup-arm64.sh
+++ b/remote-script/05-graalvm-setup-arm64.sh
@@ -11,10 +11,10 @@ sudo su <<EOT
 mkdir -p /opt
 cd /opt
 
-curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_VERSION}/graalvm-community-jdk-${JAVAVM_VERSION}_linux-aarch64_bin.tar.gz
+curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_JDK_TAG}/graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-aarch64_bin.tar.gz
 
-tar -xzf graalvm-community-jdk-${JAVAVM_VERSION}_linux-aarch64_bin.tar.gz || exit 1
-rm -f graalvm-community-jdk-${JAVAVM_VERSION}_linux-aarch64_bin.tar.gz || exit 1
+tar -xzf graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-aarch64_bin.tar.gz || exit 1
+rm -f graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-aarch64_bin.tar.gz || exit 1
 
 p=\$(ls -t | head -1)
 ln -s  ./"\$p"  ./graalvm

--- a/remote-script/05-graalvm-setup-arm64.sh
+++ b/remote-script/05-graalvm-setup-arm64.sh
@@ -8,21 +8,17 @@ echo "------------------------------------------------------------------------"
 
 
 sudo su <<EOT
-
 mkdir -p /opt
 cd /opt
 
-curl -LO -f https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAALVM_VERSION}/graalvm-community-jdk-${GRAALVM_VERSION}_linux-aarch64_bin.tar.gz
+curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_VERSION}/graalvm-community-jdk-${JAVAVM_VERSION}_linux-aarch64_bin.tar.gz
 
-
-tar -xzf graalvm-community-jdk-${GRAALVM_VERSION}_linux-aarch64_bin.tar.gz || exit 1
-rm -f graalvm-community-jdk-${GRAALVM_VERSION}_linux-aarch64_bin.tar.gz || exit 1
-
+tar -xzf graalvm-community-jdk-${JAVAVM_VERSION}_linux-aarch64_bin.tar.gz || exit 1
+rm -f graalvm-community-jdk-${JAVAVM_VERSION}_linux-aarch64_bin.tar.gz || exit 1
 
 p=\$(ls -t | head -1)
 ln -s  ./"\$p"  ./graalvm
 echo "ln -s  ./\$p   ./graalvm"
-
 
 touch /etc/profile.d/graalvm.sh
 chown root:root /etc/profile.d/graalvm.sh
@@ -33,5 +29,4 @@ echo "export PATH=/opt/graalvm/bin:\$PATH" >> /etc/profile.d/graalvm.sh
 echo "export JAVA_HOME=/opt/graalvm" >> /etc/profile.d/graalvm.sh
 
 ln -s /opt/graalvm/bin/java /usr/bin/java
-
 EOT

--- a/remote-script/05-graalvm-setup-x86.sh
+++ b/remote-script/05-graalvm-setup-x86.sh
@@ -11,26 +11,22 @@ sudo su <<EOT
 mkdir -p /opt
 cd /opt
 
-curl -LO -f https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAALVM_VERSION}/graalvm-community-jdk-${GRAALVM_VERSION}_linux-x64_bin.tar.gz
-df -h
-tar -xzf graalvm-community-jdk-${GRAALVM_VERSION}_linux-x64_bin.tar.gz || exit 1
-rm -f graalvm-community-jdk-${GRAALVM_VERSION}_linux-x64_bin.tar.gz || exit 1
+curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_VERSION}/graalvm-community-jdk-${JAVAVM_VERSION}_linux-x64_bin.tar.gz
 
+tar -xzf graalvm-community-jdk-${JAVAVM_VERSION}_linux-x64_bin.tar.gz || exit 1
+rm -f graalvm-community-jdk-${JAVAVM_VERSION}_linux-x64_bin.tar.gz || exit 1
 
 p=\$(ls -t | head -1)
 ln -s  ./"\$p"  ./graalvm
 echo "ln -s  ./\$p   ./graalvm"
 
-
 touch /etc/profile.d/graalvm.sh
 chown root:root /etc/profile.d/graalvm.sh
 chmod 644 /etc/profile.d/graalvm.sh
-
 
 echo "# /etc/profile.d/graalvm   - graalvm paths  " >> /etc/profile.d/graalvm.sh
 echo "export PATH=/opt/graalvm/bin:\$PATH" >> /etc/profile.d/graalvm.sh
 echo "export JAVA_HOME=/opt/graalvm" >> /etc/profile.d/graalvm.sh
 
 ln -s /opt/graalvm/bin/java /usr/bin/java
-
 EOT

--- a/remote-script/05-graalvm-setup-x86.sh
+++ b/remote-script/05-graalvm-setup-x86.sh
@@ -11,7 +11,7 @@ sudo su <<EOT
 mkdir -p /opt
 cd /opt
 
-curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_JDK_TAG}/graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-x64_bin.tar.gz
+curl -LO -f https://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_JDK_TAG}/graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-x64_bin.tar.gz
 
 tar -xzf graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-x64_bin.tar.gz || exit 1
 rm -f graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-x64_bin.tar.gz || exit 1

--- a/remote-script/05-graalvm-setup-x86.sh
+++ b/remote-script/05-graalvm-setup-x86.sh
@@ -11,10 +11,10 @@ sudo su <<EOT
 mkdir -p /opt
 cd /opt
 
-curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_VERSION}/graalvm-community-jdk-${JAVAVM_VERSION}_linux-x64_bin.tar.gz
+curl -LO -fhttps://github.com/graalvm/graalvm-ce-builds/releases/download/graal-${GRAALVM_JDK_TAG}/graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-x64_bin.tar.gz
 
-tar -xzf graalvm-community-jdk-${JAVAVM_VERSION}_linux-x64_bin.tar.gz || exit 1
-rm -f graalvm-community-jdk-${JAVAVM_VERSION}_linux-x64_bin.tar.gz || exit 1
+tar -xzf graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-x64_bin.tar.gz || exit 1
+rm -f graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-x64_bin.tar.gz || exit 1
 
 p=\$(ls -t | head -1)
 ln -s  ./"\$p"  ./graalvm


### PR DESCRIPTION
Titre : Fix graal chains for GraalVM's new 'inovative' version numbering

Corps :

!!! DO NOT REVIEW BEFORE GO FROM G&G's R&D !!!

## Summary
- Add support for the new `--javavm-version` parameter (GraalVM's new "inovative" numbering scheme) across all graal build chains: AWS ARM, AWS x86, Azure x86, and GCP x86
- Bump `graalvm-version` to `25.2.4` and pass `javavm-version 25i2-25.0.4` in each `*-graal-latest.yml` workflow
- Fix bugs found along the way:
  - `build-aws-arm-graal.sh`: missing `--javavm-version` parsing, `exit` without code on invalid args
  - `build-azure-x86-graal.sh`: validation referencing undefined AWS-leftover variables, missing `--javavm-version` parsing
  - `build-gcp-x86-graal.sh`: missing `--javavm-version` parsing, `exit` without code on invalid args
  - `packer/aws-x86-graal.pkr.hcl`: double `=` typo in `JAVAVM_VERSION` env var
  - `packer/azure-x86-graal.pkr.hcl`, `packer/gcp-x86-graal.pkr.hcl`: missing `javavm_version` variable and `JAVAVM_VERSION` env var passed to the provisioner
  - `remote-script/05-graalvm-setup-{arm64,x86}.sh`: updated download URL to use `GRAALVM_VERSION` for the release tag and `JAVAVM_VERSION` for the jdk archive name

Only graal-related files were touched — no zulu/java chains were modified.

## Test plan
- [ ] Run `AWS arm graalvm latest` workflow manually
- [ ] Run `AWS x86 graalvm latest` workflow manually
- [ ] Run `Azure x86 Graal latest` workflow manually
- [ ] Run `GCP x86 graalvm latest` workflow manually
- [ ] Confirm each produces a bootable image with the correct GraalVM version installed

!!! DO NOT REVIEW BEFORE GO FROM G&G's R&D !!!